### PR TITLE
[FIX] add t-nocache attribute to is_public_user() check

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ addon | version | maintainers | summary
 [website_event_responsible_contact_info_visibility](website_event_responsible_contact_info_visibility/) | 17.0.1.0.0 |  | Set per event if Responsible user and their phone, mobile and/or email should be shown
 [website_event_rss_feed](website_event_rss_feed/) | 17.0.1.0.2 |  | Ability to create custom RSS Feeds with events of multiple event tags
 [website_event_sale_disable_qty_in_cart](website_event_sale_disable_qty_in_cart/) | 17.0.1.0.0 |  | Disable changing Event Registration qty in cart
-[website_event_sale_force_login](website_event_sale_force_login/) | 17.0.1.1.1 |  | Force login before registering to an event
+[website_event_sale_force_login](website_event_sale_force_login/) | 17.0.1.2.0 |  | Force login before registering to an event
 [website_event_sale_go_to_payment_button_configurable_label](website_event_sale_go_to_payment_button_configurable_label/) | 17.0.1.0.0 |  | Customize payment and registration button texts in event registration
 [website_event_sale_waiting_list](website_event_sale_waiting_list/) | 17.0.1.0.1 |  | Register to events using waiting list through website.
 [website_event_settings](website_event_settings/) | 17.0.1.0.1 |  | Website Event Settings

--- a/website_event_sale_force_login/README.rst
+++ b/website_event_sale_force_login/README.rst
@@ -16,6 +16,15 @@ Usage
 =====
 \-
 
+Changelog
+=========
+
+17.0.1.2.0
+~~~~~~~~~~
+
+* t-cache attributes taken into use to mitigate issue where the result
+  of is_public_user() could be cached and produce wrong results when
+  e.g. reloading the page rapidly as a portal user.
 
 Credits
 =======
@@ -24,6 +33,7 @@ Contributors
 ------------
 
 * Jarmo Kortetjärvi <jarmo.kortetjarvi@futural.fi>
+* Timo Talvitie <timo.talvitie@futural.fi>
 
 Maintainer
 ----------

--- a/website_event_sale_force_login/__manifest__.py
+++ b/website_event_sale_force_login/__manifest__.py
@@ -21,7 +21,7 @@
 {
     "name": "Event eCommerce: Force login",
     "summary": "Force login before registering to an event",
-    "version": "17.0.1.1.1",
+    "version": "17.0.1.2.0",
     "category": "Website",
     "website": "https://github.com/tawasta/event",
     "author": "Futural",

--- a/website_event_sale_force_login/views/website_registration_template.xml
+++ b/website_event_sale_force_login/views/website_registration_template.xml
@@ -12,6 +12,7 @@
             <attribute
                 name="t-if"
             >event.event_registrations_open and (event.allow_guest_registration or not website.is_public_user())</attribute>
+            <attribute name="t-nocache">Avoid caching public user checks</attribute>
         </xpath>
 
         <xpath
@@ -21,6 +22,7 @@
             <t
                 t-if="website.is_public_user() and not event.allow_guest_registration"
                 t-call="website_sale_force_login.product_login_buttons"
+                t-nocache="Avoid caching public user checks"
             />
         </xpath>
 


### PR DESCRIPTION
- previously the check could give a wrong result when e.g. portal user reloaded the page rapidly multiple times