### PR TITLE
[FIX] email preview language not working

### DIFF
--- a/event_access_mail_template_preview_from_event_form/__manifest__.py
+++ b/event_access_mail_template_preview_from_event_form/__manifest__.py
@@ -28,6 +28,6 @@
     "license": "AGPL-3",
     "application": False,
     "installable": True,
-    "depends": ["event", "mail"],
+    "depends": ["event", "mail", "partner_event"],
     "data": ["views/event_event.xml", "data/ir_cron.xml"],
 }

--- a/event_access_mail_template_preview_from_event_form/models/event_mail.py
+++ b/event_access_mail_template_preview_from_event_form/models/event_mail.py
@@ -29,6 +29,10 @@ class EventMail(models.Model):
                 }
             )
 
+            # This is a hacky workaround to get the previewed email's language to not
+            # force itself to english.
+            registration.partner_id = registration.attendee_partner_id.id
+
             return registration
 
     def action_launch_email_template_preview(self):


### PR DESCRIPTION
- our email templates of website_event_waiting_list pull their language from registration.partner_id. partner assignation of this commit fixes the issue of the preview always being in english, regardless of the placeholder partner's language